### PR TITLE
Use datetype for expiry

### DIFF
--- a/src/main/java/seedu/mtracker/LogHelper.java
+++ b/src/main/java/seedu/mtracker/LogHelper.java
@@ -16,7 +16,7 @@ public class LogHelper {
     public static final String LOG_INVALID_SENTIMENT = "User tried to enter an invalid sentiment here";
     public static final String LOG_EMPTY_PAST_RETURNS = "User left past returns empty. Defaulting to double -101.0";
     public static final String LOG_EMPTY_EXPIRY = "User left expiry empty.";
-    public static final String LOG_INVALID_EXPIRY = "User gave an expiry input that cannot be parsed into date";
+    public static final String LOG_INVALID_EXPIRY = "User gave an invalid expiry input";
     public static final String LOG_INVALID_INSTRUMENT = "User tried to add an invalid instrument type here";
     public static final String LOG_INVALID_COMMAND = "User entered an invalid command to console here";
 

--- a/src/main/java/seedu/mtracker/LogHelper.java
+++ b/src/main/java/seedu/mtracker/LogHelper.java
@@ -16,6 +16,7 @@ public class LogHelper {
     public static final String LOG_INVALID_SENTIMENT = "User tried to enter an invalid sentiment here";
     public static final String LOG_EMPTY_PAST_RETURNS = "User left past returns empty. Defaulting to double -101.0";
     public static final String LOG_EMPTY_EXPIRY = "User left expiry empty.";
+    public static final String LOG_INVALID_EXPIRY = "User gave an expiry input that cannot be parsed into date";
     public static final String LOG_INVALID_INSTRUMENT = "User tried to add an invalid instrument type here";
     public static final String LOG_INVALID_COMMAND = "User entered an invalid command to console here";
 

--- a/src/main/java/seedu/mtracker/commands/AddCryptoCommand.java
+++ b/src/main/java/seedu/mtracker/commands/AddCryptoCommand.java
@@ -3,17 +3,19 @@ package seedu.mtracker.commands;
 import seedu.mtracker.instrument.subinstrument.Crypto;
 import seedu.mtracker.ui.TextUi;
 
+import java.time.LocalDate;
+
 public class AddCryptoCommand extends AddInstrumentCommand {
 
     public static final String COMMAND_WORD = "crypto";
 
     public static final int EXPIRY_INDEX = 3;
     public static final int REMARK_INDEX = 4;
+    protected LocalDate expiryParameter;
     protected String remarkParameter;
-    protected String expiryParameter;
 
     public void setCryptoParameters() {
-        expiryParameter = inputParameters.get(EXPIRY_INDEX);
+        expiryParameter = LocalDate.parse(inputParameters.get(EXPIRY_INDEX));
         remarkParameter = inputParameters.get(REMARK_INDEX);
     }
 

--- a/src/main/java/seedu/mtracker/commands/AddForexCommand.java
+++ b/src/main/java/seedu/mtracker/commands/AddForexCommand.java
@@ -3,6 +3,8 @@ package seedu.mtracker.commands;
 import seedu.mtracker.instrument.subinstrument.Forex;
 import seedu.mtracker.ui.TextUi;
 
+import java.time.LocalDate;
+
 public class AddForexCommand extends AddInstrumentCommand {
     public static final String COMMAND_WORD = "forex";
 
@@ -13,13 +15,13 @@ public class AddForexCommand extends AddInstrumentCommand {
 
     protected double entryPriceParameter;
     protected double exitPriceParameter;
-    protected String expiryParameter;
+    protected LocalDate expiryParameter;
     protected String remarkParameter;
 
     public void setForexParameters() {
         entryPriceParameter = Double.parseDouble(inputParameters.get(ENTRY_INDEX));
         exitPriceParameter = Double.parseDouble(inputParameters.get(EXIT_INDEX));
-        expiryParameter = inputParameters.get(EXPIRY_INDEX);
+        expiryParameter = LocalDate.parse(inputParameters.get(EXPIRY_INDEX));
         remarkParameter = inputParameters.get(REMARK_INDEX);
     }
 

--- a/src/main/java/seedu/mtracker/console/AddCryptoParser.java
+++ b/src/main/java/seedu/mtracker/console/AddCryptoParser.java
@@ -23,7 +23,7 @@ public class AddCryptoParser extends AddInstrumentParser {
         String expiry;
         do {
             expiry = getCryptoExpiryFromUser();
-        } while (!isExpiryFilled(expiry));
+        } while (!isValidExpiry(expiry));
         parameters.add(expiry);
     }
 

--- a/src/main/java/seedu/mtracker/console/AddForexParser.java
+++ b/src/main/java/seedu/mtracker/console/AddForexParser.java
@@ -57,7 +57,7 @@ public class AddForexParser extends AddInstrumentParser {
         String expiry;
         do {
             expiry = getForexExpiryFromUser();
-        } while (!isExpiryFilled(expiry));
+        } while (!isValidExpiry(expiry));
         parameters.add(expiry);
         AssertParserHelper.assertInputNotEmpty(expiry);
     }

--- a/src/main/java/seedu/mtracker/console/AddInstrumentParser.java
+++ b/src/main/java/seedu/mtracker/console/AddInstrumentParser.java
@@ -11,6 +11,8 @@ import seedu.mtracker.error.ErrorMessage;
 import seedu.mtracker.error.InvalidInstrumentError;
 import seedu.mtracker.ui.TextUi;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.logging.Logger;
 
@@ -89,18 +91,23 @@ public abstract class AddInstrumentParser extends InputParser {
         return isValid;
     }
 
-    public static boolean isExpiryFilled(String expiryInput) {
-        boolean isFilled = true;
+    public static boolean isValidExpiry(String expiryInput) {
+        boolean isValid = true;
         try {
             if (expiryInput.isEmpty()) {
                 throw new IllegalArgumentException();
             }
+            LocalDate.parse(expiryInput);
         } catch (IllegalArgumentException e) {
             logger.info(LogHelper.LOG_EMPTY_EXPIRY);
             ErrorMessage.displayEmptyExpiryError();
-            isFilled = false;
+            isValid = false;
+        } catch (DateTimeParseException e) {
+            logger.info(LogHelper.LOG_INVALID_EXPIRY);
+            ErrorMessage.displayInvalidExpiryError();
+            isValid = false;
         }
-        return isFilled;
+        return isValid;
     }
 
     public static void addCurrentPriceToParameters() {

--- a/src/main/java/seedu/mtracker/console/AddInstrumentParser.java
+++ b/src/main/java/seedu/mtracker/console/AddInstrumentParser.java
@@ -8,13 +8,13 @@ import seedu.mtracker.commands.AddForexCommand;
 import seedu.mtracker.commands.AddInstrumentCommand;
 import seedu.mtracker.commands.AddStockCommand;
 import seedu.mtracker.error.ErrorMessage;
+import seedu.mtracker.error.InvalidDateError;
 import seedu.mtracker.error.InvalidInstrumentError;
 import seedu.mtracker.ui.TextUi;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
-import java.util.logging.Logger;
 
 public abstract class AddInstrumentParser extends InputParser {
 
@@ -91,20 +91,38 @@ public abstract class AddInstrumentParser extends InputParser {
         return isValid;
     }
 
+    public static void checkDateFormat(String expiryInput) throws InvalidDateError {
+        try {
+            LocalDate.parse(expiryInput);
+        } catch (DateTimeParseException e) {
+            throw new InvalidDateError();
+        }
+    }
+
+    public static void checkDateInPast(String expiryInput) throws InvalidDateError {
+        LocalDate givenDate = LocalDate.parse(expiryInput);
+        if (givenDate.equals(LocalDate.now()) || givenDate.isAfter(LocalDate.now())) {
+            return;
+        }
+
+        throw new InvalidDateError();
+    }
+
     public static boolean isValidExpiry(String expiryInput) {
         boolean isValid = true;
         try {
             if (expiryInput.isEmpty()) {
                 throw new IllegalArgumentException();
             }
-            LocalDate.parse(expiryInput);
+            checkDateFormat(expiryInput);
+            checkDateInPast(expiryInput);
         } catch (IllegalArgumentException e) {
             logger.info(LogHelper.LOG_EMPTY_EXPIRY);
             ErrorMessage.displayEmptyExpiryError();
             isValid = false;
-        } catch (DateTimeParseException e) {
+        } catch (InvalidDateError e) {
             logger.info(LogHelper.LOG_INVALID_EXPIRY);
-            ErrorMessage.displayInvalidExpiryError();
+            TextUi.showErrorMessage(e);
             isValid = false;
         }
         return isValid;

--- a/src/main/java/seedu/mtracker/error/ErrorMessage.java
+++ b/src/main/java/seedu/mtracker/error/ErrorMessage.java
@@ -22,6 +22,10 @@ public abstract class ErrorMessage {
     }
 
     public static void displayEmptyExpiryError() {
-        System.out.println("Sorry there must be an expiry date/time for this instrument signal!");
+        System.out.println("Sorry there must be an expiry date for this instrument signal!");
+    }
+
+    public static void displayInvalidExpiryError() {
+        System.out.println("Sorry expiry must be a valid date and in YYYY-MM-DD format!");
     }
 }

--- a/src/main/java/seedu/mtracker/error/ErrorMessage.java
+++ b/src/main/java/seedu/mtracker/error/ErrorMessage.java
@@ -4,6 +4,8 @@ public abstract class ErrorMessage {
 
     public static final String INVALID_INSTRUMENT_GIVEN_ERROR = "Invalid Instrument given!";
     public static final String INVALID_COMMAND_GIVEN_ERROR = "Oops, I do not understand you...";
+    public static final String INVALID_DATE_GIVEN_ERROR = "Oops, expiry must be a valid date in the future "
+        + "and in YYYY-MM-DD format";
 
     public static void displayAddInstrumentNameError(String instrumentType) {
         System.out.println("Sorry " + instrumentType + " cannot have an empty name!");

--- a/src/main/java/seedu/mtracker/error/InvalidDateError.java
+++ b/src/main/java/seedu/mtracker/error/InvalidDateError.java
@@ -1,0 +1,8 @@
+package seedu.mtracker.error;
+
+public class InvalidDateError extends Exception {
+    @Override
+    public String getMessage() {
+        return ErrorMessage.INVALID_DATE_GIVEN_ERROR;
+    }
+}

--- a/src/main/java/seedu/mtracker/instrument/Instrument.java
+++ b/src/main/java/seedu/mtracker/instrument/Instrument.java
@@ -2,17 +2,19 @@ package seedu.mtracker.instrument;
 
 public abstract class Instrument {
 
+    public static final String DATE_REGEX = "MMM dd yyyy";
+
     protected String name;
     protected double currentPrice;
     protected String sentiment;
 
+    protected static final String EXPIRY_HEADER = "Expiry: ";
+    protected static final String REMARKS_HEADER = "Remarks: ";
+    protected static final String EMPTY_STRING = "";
     private static final String TYPE_HEADER = "Type: ";
     private static final String NAME_HEADER = "Name: ";
     private static final String CURRENT_PRICE_HEADER = "Current Price: ";
     private static final String SENTIMENT_HEADER = "Sentiment: ";
-    protected static final String EXPIRY_HEADER = "Expiry: ";
-    protected static final String REMARKS_HEADER = "Remarks: ";
-    protected static final String EMPTY_STRING = "";
 
     public Instrument(String name, double currentPrice, String sentiment) {
         this.name = name;

--- a/src/main/java/seedu/mtracker/instrument/subinstrument/Crypto.java
+++ b/src/main/java/seedu/mtracker/instrument/subinstrument/Crypto.java
@@ -3,21 +3,24 @@ package seedu.mtracker.instrument.subinstrument;
 import seedu.mtracker.instrument.Instrument;
 import seedu.mtracker.ui.TextUi;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
 public class Crypto extends Instrument {
 
-    protected String expiry;
+    protected LocalDate expiry;
     protected String remark;
     protected static final String CRYPTO_ICON = "C";
     protected static final String TYPE_INSTRUMENT = "Crypto";
 
-    public Crypto(String name, double currentPrice, String sentiment, String expiry, String remark) {
+    public Crypto(String name, double currentPrice, String sentiment, LocalDate expiry, String remark) {
         super(name, currentPrice, sentiment);
         this.expiry = expiry;
         this.remark = remark;
     }
 
     public String getExpiry() {
-        return expiry;
+        return expiry.format(DateTimeFormatter.ofPattern(DATE_REGEX));
     }
 
     public String getRemark() {

--- a/src/main/java/seedu/mtracker/instrument/subinstrument/Forex.java
+++ b/src/main/java/seedu/mtracker/instrument/subinstrument/Forex.java
@@ -3,10 +3,13 @@ package seedu.mtracker.instrument.subinstrument;
 import seedu.mtracker.instrument.Instrument;
 import seedu.mtracker.ui.TextUi;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
 public class Forex extends Instrument {
     protected double entryPrice;
     protected double exitPrice;
-    protected String expiry;
+    protected LocalDate expiry;
     protected String remark;
 
     private static final String FX_ICON = "F";
@@ -20,7 +23,7 @@ public class Forex extends Instrument {
             String sentiment,
             double entryPrice,
             double exitPrice,
-            String expiry,
+            LocalDate expiry,
             String remark
     ) {
         super(name, currentPrice, sentiment);
@@ -40,7 +43,7 @@ public class Forex extends Instrument {
     }
 
     public String getExpiry() {
-        return expiry;
+        return expiry.format(DateTimeFormatter.ofPattern(DATE_REGEX));
     }
 
     public String getRemarks() {

--- a/src/main/java/seedu/mtracker/ui/TextUi.java
+++ b/src/main/java/seedu/mtracker/ui/TextUi.java
@@ -53,7 +53,7 @@ public class TextUi {
     }
 
     public static void displayAddExpiryInstruction() {
-        System.out.println(TAB + "Expiry: ");
+        System.out.println(TAB + "Expiry (YYYY-MM-DD): ");
     }
 
     public static void displayAddEntryPriceInstruction() {

--- a/src/test/java/seedu/mtracker/console/AddCryptoParserTest.java
+++ b/src/test/java/seedu/mtracker/console/AddCryptoParserTest.java
@@ -3,26 +3,46 @@ package seedu.mtracker.console;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
+import java.time.LocalDate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class AddCryptoParserTest {
     public static final int PARAMETER_SIZE = 5;
+    public static final int DAYS_DIFFERENCE = 1;
+    public static final LocalDate futureDate = LocalDate.now().plusDays(DAYS_DIFFERENCE);
 
-    public static final String USER_INPUT_NO_REMARKS = "TestName%1$s23.4%1$spositive%1$s18 Oct%1$s ";
-    public static final String[] EXPECTED_PARAMS_NO_REMARKS = {"TestName", "23.4", "positive", "18 Oct", ""};
+    public static final String USER_INPUT_NO_REMARKS = "TestName%1$s23.4%1$spositive%1$s"
+            + futureDate
+            + "%1$s ";
 
-    public static final String USER_INPUT_WITH_REMARKS_AND_EXPIRY = "TestName%1$s100.4%1$snegative"
-            + "%1$s18 Oct%1$sTestRemarks";
+    public static final String[] EXPECTED_PARAMS_NO_REMARKS = {"TestName", "23.4", "positive", futureDate.toString(),
+        ""};
+
+    public static final String USER_INPUT_WITH_REMARKS_AND_EXPIRY = "TestName%1$s100.4%1$snegative%1$s"
+            + futureDate
+            + "%1$sTestRemarks";
+
     public static final String[] EXPECTED_PARAMS_WITH_REMARKS_AND_EXPIRY = {"TestName", "100.4", "negative",
-        "18 Oct", "TestRemarks"};
-    public static final String USER_INPUT_TRY_INVALID_NAME = "%1$s%1$s%1$sTestName%1$s23.4%1$spositive%1$s18 Oct%1$s ";
+        futureDate.toString(), "TestRemarks"};
+
+    public static final String USER_INPUT_TRY_INVALID_NAME = "%1$s%1$s%1$sTestName%1$s23.4%1$spositive%1$s"
+            + futureDate
+            + "%1$s ";
+
     public static final String USER_INPUT_TRY_INVALID_PRICE = "%1$sTestName%1$s2sd3.4%1$s100.4"
-            + "%1$snegative%1$s18 Oct%1$sTestRemarks";
+            + "%1$snegative%1$s"
+            + futureDate
+            + "%1$sTestRemarks";
+
     public static final String USER_INPUT_TRY_INVALID_SENTIMENT = "%1$sTestName%1$s100.4"
-            + "%1$swrong%1$s%1$snegative%1$s18 Oct%1$sTestRemarks";
+            + "%1$swrong%1$s%1$snegative%1$s"
+            + futureDate
+            + "%1$sTestRemarks";
     public static final String USER_INPUT_TRY_EMPTY_EXPIRY = "%1$sTestName%1$s100.4"
-            + "%1$snegative%1$s %1$s %1$s18 Oct%1$sTestRemarks";
+            + "%1$snegative%1$s %1$s %1$s"
+            + futureDate
+            + "%1$sTestRemarks";
 
     String formatConsoleInput(String input) {
         return String.format(input, System.lineSeparator());

--- a/src/test/java/seedu/mtracker/console/AddForexParserTest.java
+++ b/src/test/java/seedu/mtracker/console/AddForexParserTest.java
@@ -3,12 +3,15 @@ package seedu.mtracker.console;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
+import java.time.LocalDate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class AddForexParserTest {
 
     public static final int PARAMETER_SIZE = 7;
+    public static final int DAYS_DIFFERENCE = 1;
+    public static final LocalDate futureDate = LocalDate.now().plusDays(DAYS_DIFFERENCE);
     private static final String SEPARATOR_SPECIFIERS = "%1$s";
 
     public static final String[] EXPECTED_PARAMS_NO_REMARKS = {
@@ -17,7 +20,7 @@ class AddForexParserTest {
         "positive",
         "1.15",
         "1.30",
-        "15 Oct",
+        futureDate.toString(),
         ""
     };
 
@@ -27,7 +30,7 @@ class AddForexParserTest {
         "negative",
         "0.79",
         "0.70",
-        "20 Oct",
+        futureDate.toString(),
         "fooRemarks"
     };
 
@@ -36,7 +39,7 @@ class AddForexParserTest {
             + SEPARATOR_SPECIFIERS + "positive"
             + SEPARATOR_SPECIFIERS + "1.15"
             + SEPARATOR_SPECIFIERS + "1.30"
-            + SEPARATOR_SPECIFIERS + "15 Oct"
+            + SEPARATOR_SPECIFIERS + futureDate
             + SEPARATOR_SPECIFIERS + " ";
 
     public static final String USER_INPUT_WITH_REMARKS = "TTTXXX"
@@ -44,7 +47,7 @@ class AddForexParserTest {
             + SEPARATOR_SPECIFIERS + "negative"
             + SEPARATOR_SPECIFIERS + "0.79"
             + SEPARATOR_SPECIFIERS + "0.70"
-            + SEPARATOR_SPECIFIERS + "20 Oct"
+            + SEPARATOR_SPECIFIERS + futureDate
             + SEPARATOR_SPECIFIERS + "fooRemarks";
 
     public static final String USER_INPUT_TRY_INVALID_NAME = SEPARATOR_SPECIFIERS.repeat(2) + "TTXX"
@@ -53,7 +56,7 @@ class AddForexParserTest {
             + SEPARATOR_SPECIFIERS + "positive"
             + SEPARATOR_SPECIFIERS + "1.15"
             + SEPARATOR_SPECIFIERS + "1.30"
-            + SEPARATOR_SPECIFIERS + "15 Oct"
+            + SEPARATOR_SPECIFIERS + futureDate
             + SEPARATOR_SPECIFIERS + " ";
 
     public static final String USER_INPUT_TRY_INVALID_PRICE = SEPARATOR_SPECIFIERS + "TTTXXX"
@@ -63,7 +66,7 @@ class AddForexParserTest {
             + SEPARATOR_SPECIFIERS + "foobar"
             + SEPARATOR_SPECIFIERS + "0.79"
             + SEPARATOR_SPECIFIERS.repeat(2) + "0.70"
-            + SEPARATOR_SPECIFIERS + "20 Oct"
+            + SEPARATOR_SPECIFIERS + futureDate
             + SEPARATOR_SPECIFIERS + "fooRemarks";
 
     public static final String USER_INPUT_TRY_INVALID_SENTIMENT = SEPARATOR_SPECIFIERS + "TTTXXX"
@@ -72,7 +75,7 @@ class AddForexParserTest {
             + SEPARATOR_SPECIFIERS.repeat(2) + "negative"
             + SEPARATOR_SPECIFIERS + "0.79"
             + SEPARATOR_SPECIFIERS + "0.70"
-            + SEPARATOR_SPECIFIERS + "20 Oct"
+            + SEPARATOR_SPECIFIERS + futureDate
             + SEPARATOR_SPECIFIERS + "fooRemarks";
 
     String formatConsoleInput(String input) {

--- a/src/test/java/seedu/mtracker/console/AddInstrumentParserTest.java
+++ b/src/test/java/seedu/mtracker/console/AddInstrumentParserTest.java
@@ -2,6 +2,7 @@ package seedu.mtracker.console;
 
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDate;
 import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -9,53 +10,79 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class AddInstrumentParserTest {
 
-    public static String emptyInput = "";
-    public static String validTestName = "testName";
-    public static String validPrice = "123.43";
-    public static String invalidPrice = "32fvr";
-    public static String[] validSentiments = {"positive", "neutral", "negative"};
-    public static String invalidSentiment = "invalid";
+    public static final String EMPTY_INPUT = "";
+    public static final String VALID_TEST_NAME = "testName";
+    public static final String VALID_PRICE = "123.43";
+    public static final String INVALID_PRICE = "32fvr";
+    public static final String[] VALID_SENTIMENTS = {"positive", "neutral", "negative"};
+    public static final String INVALID_SENTIMENT = "invalid";
+    public static final String INVALID_EXPIRY = "18 Oct";
+    public static final int DAYS_DIFFERENCE = 1;
 
     public static String validTestInstrument = "testInstrument";
 
     @Test
     void addName_validName_expectSuccess() {
-        assertTrue(AddInstrumentParser.isValidName(validTestName, validTestInstrument));
+        assertTrue(AddInstrumentParser.isValidName(VALID_TEST_NAME, validTestInstrument));
     }
 
     @Test
     void addName_emptyName_expectFailure() {
-        assertFalse(AddInstrumentParser.isValidName(emptyInput, validTestInstrument));
+        assertFalse(AddInstrumentParser.isValidName(EMPTY_INPUT, validTestInstrument));
     }
 
     @Test
     void addCurrentPrice_validNumber_expectSuccess() {
-        assertTrue(AddInstrumentParser.isValidPrice(validPrice));
+        assertTrue(AddInstrumentParser.isValidPrice(VALID_PRICE));
     }
 
     @Test
     void addCurrentPrice_invalidNumber_expectFailure() {
-        assertFalse(AddInstrumentParser.isValidPrice(invalidPrice));
+        assertFalse(AddInstrumentParser.isValidPrice(INVALID_PRICE));
     }
 
     @Test
     void addCurrentPrice_emptyNumber_expectFailure() {
-        assertFalse(AddInstrumentParser.isValidPrice(emptyInput));
+        assertFalse(AddInstrumentParser.isValidPrice(EMPTY_INPUT));
     }
 
     @Test
     void addSentiment_validSentiment_expectSuccess() {
-        Arrays.stream(validSentiments)
+        Arrays.stream(VALID_SENTIMENTS)
                 .forEach((sentiment) -> assertTrue(AddInstrumentParser.isValidSentiment(sentiment)));
     }
 
     @Test
     void addSentiment_invalidSentiment_expectFailure() {
-        assertFalse(AddInstrumentParser.isValidSentiment(invalidSentiment));
+        assertFalse(AddInstrumentParser.isValidSentiment(INVALID_SENTIMENT));
     }
 
     @Test
     void addSentiment_emptySentiment_expectFailure() {
-        assertFalse(AddInstrumentParser.isValidSentiment(emptyInput));
+        assertFalse(AddInstrumentParser.isValidSentiment(EMPTY_INPUT));
+    }
+
+    @Test
+    void addExpiry_validExpiryInFutre_expectSuccess() {
+        LocalDate currDate = LocalDate.now();
+        LocalDate futureDate = currDate.plusDays(DAYS_DIFFERENCE);
+        assertTrue(AddInstrumentParser.isValidExpiry(futureDate.toString()));
+    }
+
+    @Test
+    void addExpiry_emptyExpiry_expectFailure() {
+        assertFalse(AddInstrumentParser.isValidExpiry(EMPTY_INPUT));
+    }
+
+    @Test
+    void addExpiry_invalidExpiry_expectFailure() {
+        assertFalse(AddInstrumentParser.isValidExpiry(INVALID_EXPIRY));
+    }
+
+    @Test
+    void addExpiry_validExpiryButIsInPast_expectFailure() {
+        LocalDate currDate = LocalDate.now();
+        LocalDate pastDate = currDate.minusDays(DAYS_DIFFERENCE);
+        assertFalse(AddInstrumentParser.isValidExpiry(pastDate.toString()));
     }
 }


### PR DESCRIPTION
- added checks to ensure user enters YYYY-MM-DD format. Also ensured that dates entered are in the future and not in the past (can be set on the day itself)
- Updated junit tests for addinstrumentparser, addcrypto and addforex
- addcrypto and addforex tests are not complete. So in v2.1 or end of v2.0 those with the least code should do this will create new issue for it

fixes: #90 